### PR TITLE
Initialize daily_transaction_fees aggregation

### DIFF
--- a/aggregations/__init__.py
+++ b/aggregations/__init__.py
@@ -9,8 +9,6 @@ from .db_tables.daily_new_unique_contracts_count import DailyNewUniqueContractsC
 from .db_tables.daily_receipts_per_contract_count import DailyReceiptsPerContractCount
 from .db_tables.daily_transaction_fees import DailyTransactionFees
 from .db_tables.daily_transactions_count import DailyTransactionsCount
-from .db_tables.daily_transactions_per_account_count import (
-    DailyTransactionsPerAccountCount,
-)
+from .db_tables.daily_transactions_per_account_count import DailyTransactionsPerAccountCount
 from .db_tables.deployed_contracts import DeployedContracts
 from .db_tables.weekly_active_accounts_count import WeeklyActiveAccountsCount

--- a/aggregations/__init__.py
+++ b/aggregations/__init__.py
@@ -7,7 +7,10 @@ from .db_tables.daily_new_accounts_count import DailyNewAccountsCount
 from .db_tables.daily_new_contracts_count import DailyNewContractsCount
 from .db_tables.daily_new_unique_contracts_count import DailyNewUniqueContractsCount
 from .db_tables.daily_receipts_per_contract_count import DailyReceiptsPerContractCount
+from .db_tables.daily_transaction_fees import DailyTransactionFees
 from .db_tables.daily_transactions_count import DailyTransactionsCount
-from .db_tables.daily_transactions_per_account_count import DailyTransactionsPerAccountCount
+from .db_tables.daily_transactions_per_account_count import (
+    DailyTransactionsPerAccountCount,
+)
 from .db_tables.deployed_contracts import DeployedContracts
 from .db_tables.weekly_active_accounts_count import WeeklyActiveAccountsCount

--- a/aggregations/db_tables/daily_transaction_fees.py
+++ b/aggregations/db_tables/daily_transaction_fees.py
@@ -1,0 +1,45 @@
+from . import DAY_LEN_SECONDS, daily_start_of_range
+from ..periodic_aggregations import PeriodicAggregations
+
+
+class DailyTransactionFees(PeriodicAggregations):
+    @property
+    def sql_create_table(self):
+        # Use numeric(30,0) per discussion in https://github.com/near/near-analytics/issues/17.
+        return """
+            CREATE TABLE IF NOT EXISTS daily_transaction_fees
+            (
+                collected_for_day   DATE PRIMARY KEY,
+                transaction_fees    numeric(30, 0) NOT NULL
+            )
+        """
+
+    @property
+    def sql_drop_table(self):
+        return """
+            DROP TABLE IF EXISTS daily_transaction_fees
+        """
+
+    @property
+    def sql_select(self):
+        return """
+            SELECT SUM(chunks.gas_used * blocks.gas_price)
+            FROM blocks
+            JOIN chunks ON chunks.included_in_block_hash = blocks.block_hash
+            WHERE blocks.block_timestamp >= %(from_timestamp)s
+                AND blocks.block_timestamp < %(to_timestamp)s
+        """
+
+    @property
+    def sql_insert(self):
+        return """
+            INSERT INTO daily_transaction_fees VALUES %s
+            ON CONFLICT DO NOTHING
+        """
+
+    @property
+    def duration_seconds(self):
+        return DAY_LEN_SECONDS
+
+    def start_of_range(self, timestamp: int) -> int:
+        return daily_start_of_range(timestamp)

--- a/aggregations/db_tables/daily_transaction_fees.py
+++ b/aggregations/db_tables/daily_transaction_fees.py
@@ -5,12 +5,12 @@ from ..periodic_aggregations import PeriodicAggregations
 class DailyTransactionFees(PeriodicAggregations):
     @property
     def sql_create_table(self):
-        # Use numeric(30,0) per discussion in https://github.com/near/near-analytics/issues/17.
+        # Use numeric(50,0) per discussion in https://github.com/near/near-analytics/issues/17.
         return """
             CREATE TABLE IF NOT EXISTS daily_transaction_fees
             (
                 collected_for_day   DATE PRIMARY KEY,
-                transaction_fees    numeric(30, 0) NOT NULL
+                transaction_fees    numeric(50, 0) NOT NULL
             )
         """
 


### PR DESCRIPTION
Closes #17 .

Creates new `daily_transaction_fees` aggregation. The idea is to be able to calculate the transaction fees burned in yoctoNEAR.

`daily_gas_used` has been used as the reference implementation.