### PR TITLE
fix: rename transactions -> outgoing_transactions

### DIFF
--- a/aggregations/__init__.py
+++ b/aggregations/__init__.py
@@ -6,6 +6,7 @@ from .db_tables.daily_gas_used import DailyGasUsed
 from .db_tables.daily_new_accounts_count import DailyNewAccountsCount
 from .db_tables.daily_new_contracts_count import DailyNewContractsCount
 from .db_tables.daily_new_unique_contracts_count import DailyNewUniqueContractsCount
+from .db_tables.daily_outgoing_transactions_per_account_count import DailyOutgoingTransactionsPerAccountCount
 from .db_tables.daily_receipts_per_contract_count import DailyReceiptsPerContractCount
 from .db_tables.daily_tokens_spent_on_fees import DailyTokensSpentOnFees
 from .db_tables.daily_transactions_count import DailyTransactionsCount
@@ -13,4 +14,3 @@ from .db_tables.daily_transactions_per_account_count import DailyTransactionsPer
 from .db_tables.deployed_contracts import DeployedContracts
 from .db_tables.weekly_active_accounts_count import WeeklyActiveAccountsCount
 from .db_tables.near_ecosystem_entities import NearEcosystemEntities
-

--- a/aggregations/db_tables/daily_outgoing_transactions_per_account_count.py
+++ b/aggregations/db_tables/daily_outgoing_transactions_per_account_count.py
@@ -4,10 +4,7 @@ from . import DAY_LEN_SECONDS, daily_start_of_range
 from ..periodic_aggregations import PeriodicAggregations
 
 
-# DEPRECATED
-# Use DailyOutgoingTransactionsPerAccountCount instead
-# Will be deleted after migration in Explorer
-class DailyTransactionsPerAccountCount(PeriodicAggregations):
+class DailyOutgoingTransactionsPerAccountCount(PeriodicAggregations):
     @property
     def sql_create_table(self):
         # Suppose we have at most 10^5 (100K) transactions per second.
@@ -15,21 +12,21 @@ class DailyTransactionsPerAccountCount(PeriodicAggregations):
         # It gives ~10^10 transactions per day.
         # It means we fit into BIGINT (10^18)
         return '''
-            CREATE TABLE IF NOT EXISTS daily_transactions_per_account_count
+            CREATE TABLE IF NOT EXISTS daily_outgoing_transactions_per_account_count
             (
-                collected_for_day  DATE NOT NULL,
-                account_id         TEXT NOT NULL,
-                transactions_count BIGINT NOT NULL,
-                CONSTRAINT daily_transactions_per_account_count_pk PRIMARY KEY (collected_for_day, account_id)
+                collected_for_day           DATE   NOT NULL,
+                account_id                  TEXT   NOT NULL,
+                outgoing_transactions_count BIGINT NOT NULL,
+                CONSTRAINT daily_outgoing_transactions_per_account_count_pk PRIMARY KEY (collected_for_day, account_id)
             );
-            CREATE INDEX IF NOT EXISTS daily_transactions_per_account_count_idx
-                ON daily_transactions_per_account_count (collected_for_day, transactions_count DESC)
+            CREATE INDEX IF NOT EXISTS daily_outgoing_transactions_per_account_count_idx
+                ON daily_outgoing_transactions_per_account_count (collected_for_day, outgoing_transactions_count DESC)
         '''
 
     @property
     def sql_drop_table(self):
         return '''
-            DROP TABLE IF EXISTS daily_transactions_per_account_count
+            DROP TABLE IF EXISTS daily_outgoing_transactions_per_account_count
         '''
 
     @property
@@ -37,7 +34,7 @@ class DailyTransactionsPerAccountCount(PeriodicAggregations):
         return '''
             SELECT
                 signer_account_id,
-                COUNT(*) AS transactions_count
+                COUNT(*) AS outgoing_transactions_count
             FROM transactions
             WHERE transactions.block_timestamp >= %(from_timestamp)s
                 AND transactions.block_timestamp < %(to_timestamp)s
@@ -47,7 +44,7 @@ class DailyTransactionsPerAccountCount(PeriodicAggregations):
     @property
     def sql_insert(self):
         return '''
-            INSERT INTO daily_transactions_per_account_count VALUES %s
+            INSERT INTO daily_outgoing_transactions_per_account_count VALUES %s
             ON CONFLICT DO NOTHING
         '''
 

--- a/main.py
+++ b/main.py
@@ -7,8 +7,9 @@ import typing
 
 from aggregations import DailyActiveAccountsCount, DailyActiveContractsCount, DailyDeletedAccountsCount, \
     DailyDepositAmount, DailyGasUsed, DailyNewAccountsCount, DailyNewContractsCount, DailyNewUniqueContractsCount, \
-    DailyReceiptsPerContractCount, DailyTokensSpentOnFees, DailyTransactionsCount, DailyTransactionsPerAccountCount, \
-    DeployedContracts, WeeklyActiveAccountsCount, NearEcosystemEntities
+    DailyOutgoingTransactionsPerAccountCount, DailyReceiptsPerContractCount, DailyTokensSpentOnFees, \
+    DailyTransactionsCount, DailyTransactionsPerAccountCount, DeployedContracts, WeeklyActiveAccountsCount, \
+    NearEcosystemEntities
 from aggregations.db_tables import DAY_LEN_SECONDS, query_genesis_timestamp
 
 from datetime import datetime
@@ -23,6 +24,7 @@ STATS = {
     'daily_new_accounts_count': DailyNewAccountsCount,
     'daily_new_contracts_count': DailyNewContractsCount,
     'daily_new_unique_contracts_count': DailyNewUniqueContractsCount,
+    'daily_outgoing_transactions_per_account_count': DailyOutgoingTransactionsPerAccountCount,
     'daily_receipts_per_contract_count': DailyReceiptsPerContractCount,
     'daily_tokens_spent_on_fees': DailyTokensSpentOnFees,
     'daily_transactions_count': DailyTransactionsCount,


### PR DESCRIPTION
After we add #23, naming becomes confusing. I suggest to create new table with better naming, start using it in Explorer, then delete the old table.

The logic remains the same; I just renamed the table and the field inside (transactions_count -> outgoing_transactions_count).