### PR TITLE
Daily New Accounts Per Entity

### DIFF
--- a/aggregations/__init__.py
+++ b/aggregations/__init__.py
@@ -7,6 +7,7 @@ from .db_tables.daily_ingoing_transactions_per_account_count import (
     DailyIngoingTransactionsPerAccountCount,
 )
 from .db_tables.daily_new_accounts_count import DailyNewAccountsCount
+from .db_tables.daily_new_accounts_per_entity_count import DailyNewAccountsPerEntityCount
 from .db_tables.daily_new_contracts_count import DailyNewContractsCount
 from .db_tables.daily_new_unique_contracts_count import DailyNewUniqueContractsCount
 from .db_tables.daily_outgoing_transactions_per_account_count import (
@@ -16,5 +17,6 @@ from .db_tables.daily_receipts_per_contract_count import DailyReceiptsPerContrac
 from .db_tables.daily_tokens_spent_on_fees import DailyTokensSpentOnFees
 from .db_tables.daily_transactions_count import DailyTransactionsCount
 from .db_tables.deployed_contracts import DeployedContracts
+from .db_tables.entity_added_accounts import EntityAddedAccounts
 from .db_tables.weekly_active_accounts_count import WeeklyActiveAccountsCount
 from .db_tables.near_ecosystem_entities import NearEcosystemEntities

--- a/aggregations/db_tables/daily_new_accounts_per_entity_count.py
+++ b/aggregations/db_tables/daily_new_accounts_per_entity_count.py
@@ -1,0 +1,74 @@
+import datetime
+
+from . import DAY_LEN_SECONDS, daily_start_of_range, time_range_json
+from ..periodic_aggregations import PeriodicAggregations
+
+
+# This metric is computed based on `entity_added_accounts` table in Analytics DB
+class DailyNewAccountsPerEntityCount(PeriodicAggregations):
+    def dependencies(self) -> list:
+        return []
+
+    @property
+    def sql_create_table(self):
+        return """
+            CREATE TABLE IF NOT EXISTS daily_new_accounts_per_entity_count
+            (
+                collected_for_day          DATE NOT NULL,
+                entity_id                  TEXT NOT NULL,
+                new_accounts_count         BIGINT  NOT NULL,
+                CONSTRAINT daily_new_accounts_per_entity_count_pk PRIMARY KEY (collected_for_day, entity_id)
+            )
+        """
+
+    @property
+    def sql_drop_table(self):
+        return """
+            DROP TABLE IF EXISTS daily_new_accounts_per_entity_count
+        """
+
+    @property
+    def sql_select(self):
+        raise NotImplementedError(
+            "no reason to request from Indexer DB for daily_new_accounts_per_entity_count"
+        )
+
+    @property
+    def sql_insert(self):
+        return """
+            INSERT INTO daily_new_accounts_per_entity_count VALUES %s
+            ON CONFLICT DO NOTHING
+        """
+
+    def collect(self, requested_timestamp: int) -> list:
+        new_entity_users_select = """
+            SELECT
+              entity_id,
+              COUNT(*) as new_accounts_count
+            FROM entity_added_accounts
+            WHERE
+              added_at_block_timestamp >= %(from_timestamp)s
+              AND added_at_block_timestamp < %(to_timestamp)s
+            GROUP BY entity_id
+        """
+
+        from_timestamp = self.start_of_range(requested_timestamp)
+        with self.analytics_connection.cursor() as analytics_cursor:
+            analytics_cursor.execute(
+                new_entity_users_select,
+                time_range_json(from_timestamp, self.duration_seconds),
+            )
+            result = analytics_cursor.fetchall()
+            return self.prepare_data(result, start_of_range=from_timestamp)
+
+    @property
+    def duration_seconds(self):
+        return DAY_LEN_SECONDS
+
+    def start_of_range(self, timestamp: int) -> int:
+        return daily_start_of_range(timestamp)
+
+    @staticmethod
+    def prepare_data(parameters: list, **kwargs) -> list:
+        computed_for = datetime.datetime.utcfromtimestamp(kwargs['start_of_range']).strftime('%Y-%m-%d')
+        return [(computed_for, entity_id, count) for (entity_id, count) in parameters]

--- a/aggregations/db_tables/entity_added_accounts.py
+++ b/aggregations/db_tables/entity_added_accounts.py
@@ -1,0 +1,85 @@
+from ..sql_aggregations import SqlAggregations
+
+"""
+This code builds a table intended to assist with calculating statistics
+relating accounts ("added_accounts") to ecosystem entities ("entities")
+and is originally intended to be used for tracking new accounts added to each entity.
+"""
+
+class EntityAddedAccounts(SqlAggregations):
+    def dependencies(self) -> list:
+        return ["near_ecosystem_entities"]
+
+    @property
+    def sql_create_table(self):
+        return """
+            CREATE TABLE IF NOT EXISTS entity_added_accounts
+            (
+                entity_id                           TEXT,
+                account_id                          TEXT,
+                added_at_block_timestamp            BIGINT,
+                PRIMARY KEY (entity_id, account_id) -- DRAFT PR COMMENT: what are the implications of including date? can a user be removed from an entity?
+            );
+            -- intent: these indexes should build reasonably quickly compared to the runtime of the query but if they take more time than they save, please remove them!
+            CREATE INDEX IF NOT EXISTS entity_added_accounts_timestamp_entity_idx  ON entity_added_accounts (added_at_block_timestamp, entity_id);
+            CREATE INDEX IF NOT EXISTS entity_added_accounts_timestamp_account_idx ON entity_added_accounts (added_at_block_timestamp, account_id);
+         
+            CREATE INDEX IF NOT EXISTS entity_added_accounts_entity_idx  ON entity_added_accounts (entity_id);
+            CREATE INDEX IF NOT EXISTS entity_added_accounts_account_idx ON entity_added_accounts (account_id);
+        """
+
+    @property
+    def sql_drop_table(self):
+        return """
+            DROP TABLE IF EXISTS entity_added_accounts
+            """
+
+    @property
+    def sql_select(self):
+        # grab map of entity slug/contract-id pairs from near analytics db
+        # and apply that mapping to receiver entity ID's from near explore indexer db
+        # because each entity may be associated with more than one contract
+        entity_contracts_sql = """
+            SELECT
+                REPLACE(TRIM(slug),$$'$$,'')          AS entity 
+                , REPLACE(TRIM(contract_id),$$'$$,'') AS contract_id
+            FROM public.near_ecosystem_entities e, unnest(string_to_array(e.contract, ', ')) s(contract_id)
+            WHERE length(contract) > 0
+            """
+
+        with self.analytics_connection.cursor() as analytics_cursor:
+            analytics_cursor.execute(entity_contracts_sql)
+            entity_contracts = analytics_cursor.fetchall()
+        
+        indented_newline = "                    \n"
+        cases_sql = indented_newline.join([f"WHEN '{c}' THEN '{e}'" for e, c in entity_contracts])
+        
+        return """
+            WITH
+            added_to_entity_events AS
+            (
+                SELECT
+                    CASE (args -> 'access_key' -> 'permission' -> 'permission_details' ->> 'receiver_id')
+                        {cases_sql}
+                        END                         AS entity_id
+                    , receipt_receiver_account_id AS account_id
+                    , receipt_included_in_block_timestamp as added_at_timestamp
+                FROM public.action_receipt_actions
+                WHERE action_kind IN ('ADD_KEY')
+                    AND args ->'access_key' -> 'permission' ->> 'permission_kind' = 'FUNCTION_CALL'
+                GROUP BY 1, 2, 3
+            )
+            SELECT entity_id,
+            account_id,
+            MIN(added_at_timestamp) as added_at_timestamp
+            FROM added_to_entity_events
+            WHERE entity_id NOT IN (account_id, 'near')
+            GROUP BY 1, 2
+            """.format(cases_sql=cases_sql)
+
+    @property
+    def sql_insert(self):
+        return """
+            INSERT INTO entity_added_accounts VALUES %s 
+            ON CONFLICT DO NOTHING
+        """

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from aggregations import (
     DailyGasUsed,
     DailyIngoingTransactionsPerAccountCount,
     DailyNewAccountsCount,
+    DailyNewAccountsPerEntityCount,
     DailyNewContractsCount,
     DailyNewUniqueContractsCount,
     DailyOutgoingTransactionsPerAccountCount,
@@ -20,6 +21,7 @@ from aggregations import (
     DailyTokensSpentOnFees,
     DailyTransactionsCount,
     DeployedContracts,
+    EntityAddedAccounts,
     WeeklyActiveAccountsCount,
     NearEcosystemEntities,
 )
@@ -36,6 +38,7 @@ STATS = {
     "daily_gas_used": DailyGasUsed,
     "daily_ingoing_transactions_per_account_count": DailyIngoingTransactionsPerAccountCount,
     "daily_new_accounts_count": DailyNewAccountsCount,
+    "daily_new_accounts_per_entity_count": DailyNewAccountsPerEntityCount,
     "daily_new_contracts_count": DailyNewContractsCount,
     "daily_new_unique_contracts_count": DailyNewUniqueContractsCount,
     "daily_outgoing_transactions_per_account_count": DailyOutgoingTransactionsPerAccountCount,
@@ -43,6 +46,7 @@ STATS = {
     "daily_tokens_spent_on_fees": DailyTokensSpentOnFees,
     "daily_transactions_count": DailyTransactionsCount,
     "deployed_contracts": DeployedContracts,
+    "entity_added_accounts": EntityAddedAccounts,
     "weekly_active_accounts_count": WeeklyActiveAccountsCount,
     "near_ecosystem_entities": NearEcosystemEntities,
 }


### PR DESCRIPTION
create **entity_signups.py**
This code builds a table intended to assist with calculating statistics relating new accounts ("new_accounts") to app-like entities ("entities") and is originally intended to be used for tracking app signups. the terms "entity" is used in place of "app" as this logic includes all entities included in the ecosystem table and is not filtered on the app category.

If this nomenclature is believed to confuse matters, please suggest alternative names. This code was is a modified version of DeployedContracts on frol's suggestion.
Here, as in DeployedContracts, data is re-pulled in entirety for EntityAddedAccounts each time.
Please submit code suggestions if incrementally is desired!